### PR TITLE
Fix for cropped images with cache settings and  multiple srcsets.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "patches": {
       "drupal/entity_browser": {
         "Fix bug when wysiwyg embedding if a video is already embedded https://www.drupal.org/node/2822961": "https://www.drupal.org/files/issues/embedded_video_breaks-2822961-2.patch"
+      },
+      "drupal/crop": {
+        "Public folder check in crop_file_url_alter() is incorrect, does not work for responsive images https://www.drupal.org/node/2868339": "https://www.drupal.org/files/issues/crop-file-alter-make-it-really-work-2868339-4.patch"
       }
     }
   }


### PR DESCRIPTION
This occurs if you're using the Art Direction method of responsive images, including a `<picture>` element with multiple srcsets, AND the crop tool.

Behavior is that the `<img>` within the `<picture>` gets a correct hash appended to the url:

`/my-image?itok=123&h=ABC`

but srcset images don't:

`/my-image?itok=123`

This means caches aren't correctly busted unless you're looking at the fallback image within `<picture>` elements.

The patch fixes  that.