### PR TITLE
WIP: Upgrade path to core Media

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
   ],
   "require": {
     "drupal/image_widget_crop": "2.1",
+    "drupal/media_entity_image": "^1.2",
+    "drupal/media_entity_document": "^1.1",
     "drupal/entity_embed": "^1.0-beta2",
     "drupal/entity_browser": "2.0-alpha2",
     "drupal/video_embed_field": "2.0-alpha2",

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,12 @@
     }
   ],
   "require": {
-    "drupal/image_widget_crop": "1.x-dev",
+    "drupal/image_widget_crop": "2.1",
     "drupal/entity_embed": "^1.0-beta2",
-    "drupal/entity_browser": "^1.0-rc2",
-    "drupal/media_entity_image": "^1.2",
-    "drupal/media_entity_document": "^1.1",
-    "drupal/video_embed_field": "^1.3",
-    "drupal/media_entity_twitter": "^1.2",
-    "drupal/media_entity_instagram": "^1.2"
+    "drupal/entity_browser": "2.0-alpha2",
+    "drupal/video_embed_field": "2.0-alpha2",
+    "drupal/media_entity_twitter": "2.0-alpha2",
+    "drupal/media_entity_instagram": "2.0-alpha1"
   },
   "extra": {
     "patches": {

--- a/media.info.yml
+++ b/media.info.yml
@@ -3,18 +3,4 @@ description: 'Media module for Drupal 8'
 type: module
 package: Media
 core: 8.x
-dependencies:
-  - media_entity:media_entity
-  - media_entity_image:media_entity_image
-  - video_embed_field:video_embed_field
-  - video_embed_field:video_embed_media
-  - media_entity_instagram:media_entity_instagram
-  - media_entity_twitter:media_entity_twitter
-  - media_entity_document:media_entity_document
-  - entity_browser:entity_browser
-  - entity_browser:entity_browser_entity_form
-  - entity_embed:entity_embed
-  - link:link
-  - editor:editor
-  - inline_entity_form:inline_entity_form
-
+dependencies: {  }


### PR DESCRIPTION
A contrib module (admin_toolbar_tools) is incompatible with this version of the media module. We need to be ready with an upgrade path ASAP.  Upgrading instructions are written in https://www.drupal.org/project/media_entity.

Current challenges:
-- You don't need to update media_entity_image or media_entity_document to 8.2 to install the core/media module, but if you also can't update the media_entity module if media_entity_image or media_entity_document are part of your composer.json file (they require media_entity 8.1).

-- Obviously we need to figure out a way to hand off from this module to the core module. Theorizing on overwriting this module with the code from the core media module and adding an extra update hook to do any additional installation steps the core/media module does.

I would create an issue for this but I can't for some reason?